### PR TITLE
Update metamask.md so the URL works

### DIFF
--- a/docs/getting-started/metamask.md
+++ b/docs/getting-started/metamask.md
@@ -40,7 +40,7 @@ First of all we would need to connect the MetaMask with the Cronos testnet netwo
     <img src="./assets/2.png" />
 
 - Insert the network name, for example "ethermint" and put 
-  - `https://cronos-testnet－2.crypto.org:8545/` for **New RPC URL**; and 
+  - `https://cronos-testnet-2.crypto.org:8545/` for **New RPC URL**; and 
   - `338` for **Chain ID**, 
   - tcro for the symble
   - `https://cronos.crypto.org/explorer/` for the Block explorer URL as below:


### PR DESCRIPTION
Problem:
the dash in the article is not an ASCII character. It will result in Metamask throw invalid RPC url error

Solution:
1 character fix