### PR TITLE
[METAMASK] Update suggested network name

### DIFF
--- a/docs/getting-started/metamask.md
+++ b/docs/getting-started/metamask.md
@@ -41,7 +41,7 @@ First of all we would need to connect the MetaMask with the Cronos chain network
 
     <img src="./assets/2.png" />
 
-- Insert the network name, for example "ethermint" and put 
+- Insert the network name, for example "Cronos" and put 
   - `https://evm-cronos.crypto.org` for **New RPC URL**; and 
   - `25` for **Chain ID**, 
   - `CRO` for the symbol, and


### PR DESCRIPTION
Its currently suggesting to use `ethermint`, but even the demo screenshots shows `Cronos`.