### PR TITLE
Remove text "Testnet is now launched" from homepage

### DIFF
--- a/docs/.vuepress/theme/components/Home.vue
+++ b/docs/.vuepress/theme/components/Home.vue
@@ -16,9 +16,6 @@
 
 
       <div class="introduction">
-        <div class="introduction-headline">
-          Testnet is now launched!
-        </div>
         <div class="signup-newsletter-text">
           Sign up to our newsletter to get the latest updates and
         </div>
@@ -290,11 +287,6 @@ export default {
     padding 34px
     text-align center
     font-size 1.5em
-
-    .introduction-headline {
-      font-size: 40px;
-      font-weight: bold;
-    }
 
     .signup-newsletter-text {
       margin-top 20px


### PR DESCRIPTION
In this PR, I am going to update docs homepage to remove text "Testnet is now launched" as the mainnet has been live for 6 months.

Before the change:

<img width="1392" alt="image" src="https://user-images.githubusercontent.com/82353918/167577897-f67121a4-aaa0-478f-b9d2-07ff2f1e7640.png">


After the change:

<img width="1398" alt="image" src="https://user-images.githubusercontent.com/82353918/167577827-94ba4035-6c1c-4b59-87db-5d437a6c1a30.png">

