### PR TITLE
replacing the https://cronos.org/explorer/testnet3 explorer address t…

### DIFF
--- a/docs/getting-started/cronos-gamefi-integraton.md
+++ b/docs/getting-started/cronos-gamefi-integraton.md
@@ -22,13 +22,13 @@ This section showcase the Chainsafe integration with Cronos chain, aiming to bri
 
 - Below is the configuration of adding Cronos Network
   - Network Name: **Cronos Mainnet**
-    - New RPC URL: **https://evm.cronos.org/**
+    - New RPC URL: **https://evm-dev.cronos.org/**
     - Chain ID: **25**
     - Currency Symbol: **CRO**
     - Block Explorer URL: **https://cronoscan.com/**
   ***
   - Network Name: **Cronos Testnet**
-    - New RPC URL: **https://evm-t3.cronos.org/**
+    - New RPC URL: **https://evm-dev-t3.cronos.org/**
     - Chain ID: **338**
     - Currency Symbol: **TCRO**
     - Block Explorer URL: **https://testnet.cronoscan.com**

--- a/docs/getting-started/cronos-gamefi-integraton.md
+++ b/docs/getting-started/cronos-gamefi-integraton.md
@@ -22,16 +22,16 @@ This section showcase the Chainsafe integration with Cronos chain, aiming to bri
 
 - Below is the configuration of adding Cronos Network
   - Network Name: **Cronos Mainnet**
-    - New RPC URL: **https://evm-dev.cronos.org/**
+    - New RPC URL: **https://evm.cronos.org/**
     - Chain ID: **25**
     - Currency Symbol: **CRO**
     - Block Explorer URL: **https://cronoscan.com/**
   ***
   - Network Name: **Cronos Testnet**
-    - New RPC URL: **https://evm-dev-t3.cronos.org/**
+    - New RPC URL: **https://evm-t3.cronos.org/**
     - Chain ID: **338**
     - Currency Symbol: **TCRO**
-    - Block Explorer URL: **https://cronos.org/explorer/testnet3**
+    - Block Explorer URL: **https://testnet.cronoscan.com**
   - Sufficient fund on deployer address
     - [Testnet Faucet](https://cronos.crypto.org/faucet/)
 

--- a/docs/getting-started/cronos-smart-contract.md
+++ b/docs/getting-started/cronos-smart-contract.md
@@ -43,7 +43,7 @@ You can refer to [Downloading and installing Node.js and npm](https://docs.npmjs
 `Nodejs v10` is suggested 
 
 ### Sufficient fund on deployer address
-You can access to [faucet](https://cronos.org/faucet) to obtain testnet TCRO and [explorer](https://cronos.org/explorer/testnet3/) to view the address details.
+You can access to [faucet](https://cronos.org/faucet) to obtain testnet TCRO and [explorer](https://testnet.cronoscan.com/) to view the address details.
 
 ### Git clone `smart-contract-example`
   ```bash

--- a/docs/getting-started/cronos-testnet.md
+++ b/docs/getting-started/cronos-testnet.md
@@ -266,7 +266,7 @@ It should begin fetching blocks from the other peers. Please wait until it is fu
 
 ## Cronos testnet faucet and explorer
 
-- You can lookup data within the `cronostestnet_338-3` network by the [explorer](https://cronos.org/explorer/testnet3);
+- You can lookup data within the `cronostestnet_338-3` network by the [explorer](https://testnet.cronoscan.com);
 
 - To interact with the blockchain, simply use the [test-token faucet](https://cronos.org/faucet) to obtain test CRO tokens for performing transactions on the **Cronos** testnet.
 

--- a/docs/getting-started/metamask.md
+++ b/docs/getting-started/metamask.md
@@ -57,7 +57,7 @@ Similarly, for Cronos testnet, insert the network name, for example "Cronos test
   - `https://evm-t3.cronos.org` for **New RPC URL**; and 
   - `338` for **Chain ID**, 
   - `tCRO` for the symbol, and
-  - `https://cronos.org/explorer/testnet3` for the **Block explorer URL** as below:
+  - `https://testnet.cronoscan.com/` for the **Block explorer URL** as below:
 
 
 ## Importing private key to MetaMask

--- a/docs/resources/chain-integration.md
+++ b/docs/resources/chain-integration.md
@@ -138,7 +138,7 @@ If this assumption is important in your application, please consider setting up 
   - New RPC URL: **https://evm-t3.cronos.org/**
   - Chain ID: **338**
   - Currency Symbol: **TCRO**
-  - Block Explorer URL: **https://cronos.org/explorer/testnet3**
+  - Block Explorer URL: **https://testnet.cronoscan.com/**
 
 ### RPC URLs for For Cronos testnet
 
@@ -275,7 +275,7 @@ https://evm-t3.cronos.org:8545/
 - Cronos Mainnet Beta:
   [https://cronoscan.com/](https://cronoscan.com)
 - Cronos Testnet:
-  [https://cronos.org/explorer/testnet3](https://cronos.org/explorer/testnet3)
+  [https://testnet.cronoscan.com/](https://testnet.cronoscan.com/)
 
 ## Community
 


### PR DESCRIPTION
Cronoscan have just extended to **Cronos testnet** _cronostestnet_338-3_
[https://testnet.cronoscan.com/](url)