### PR TITLE
Update LimitNOFILE in mainnet_validator.md

### DIFF
--- a/docs/getting-started/mainnet_validator.md
+++ b/docs/getting-started/mainnet_validator.md
@@ -234,7 +234,7 @@ WorkingDirectory=/usr/local/bin
 ExecStart=/usr/local/bin/cronosd start --home /home/ubuntu/.cronos
 Restart=on-failure
 RestartSec=10
-LimitNOFILE=4096
+LimitNOFILE=50000
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
`LimitNOFILE` (File Descriptor Limit) is adjusted to be `50000` to prevent a potential AppHash mismatch issue.
