### PR TITLE
Display Youtube link in footer of Cronos Docs page

### DIFF
--- a/docs/.vuepress/theme/components/Footer.vue
+++ b/docs/.vuepress/theme/components/Footer.vue
@@ -73,11 +73,14 @@
           <a target="_blank" rel="noopener noreferrer" href="https://www.instagram.com/cryptocomofficial/">
             <img :src="$withBase('/social/instagram.svg')" alt="instagram" />
           </a>
+          -->
+
           <a target="_blank" rel="noopener noreferrer"
-            href="https://www.youtube.com/channel/UCOMprzxakZOqmY23LYIawmg"
+            href="https://www.youtube.com/channel/UC0VNDQLc_YHDACURNuQCZfw"
           >
             <img :src="$withBase('/social/youtube.svg')" alt="youtube" />
           </a>
+          <!--
           <a target="_blank" rel="noopener noreferrer" href="https://www.reddit.com/r/Crypto_com/">
             <img :src="$withBase('/social/reddit.svg')" alt="reddit" />
           </a> -->


### PR DESCRIPTION
Before in https://cronos.org/docs/:
<img width="419" alt="image" src="https://user-images.githubusercontent.com/82353918/173729003-360908f7-7c4e-4349-a547-ecfce69eac6c.png">



After the change:
<img width="429" alt="image" src="https://user-images.githubusercontent.com/82353918/173728944-e06d9662-42f0-47e7-a7db-28ad7554f9b3.png">
