### PR TITLE
Update 'Address Conversion' Article Title

### DIFF
--- a/for-dapp-developers/chain-integration/adress-conversion.md
+++ b/for-dapp-developers/chain-integration/adress-conversion.md
@@ -1,4 +1,4 @@
-# Adress Conversion
+# Address Conversion
 
 As explained in [chain-id.md](../../cronos-chain-protocol/chain-id.md "mention"), Cronos uses the Bech32 address format. \
 In order to convert between a Bech32 format address and an Ethereum format address, we provide the following sample code below:


### PR DESCRIPTION
The title of this article on the live page is 'Adress Conversion' and should be 'Address Conversion'.