### PR TITLE
Add NodeFlare to commercial node providers

### DIFF
--- a/for-dapp-developers/chain-integration/public-rpc-endpoints.md
+++ b/for-dapp-developers/chain-integration/public-rpc-endpoints.md
@@ -98,3 +98,7 @@ The RPC endpoints below are provided by third-party services. Please conduct tho
   * [Cronos Mainnet endpoints](https://drpc.org/chainlist/cronos-mainnet-rpc)
   * [Cronos Testnet endpoints](https://drpc.org/chainlist/cronos-testnet-rpc)
   * [Service Status](https://status.drpc.org/)
+* NodeFlare:
+  * [Cronos Mainnet endpoints](https://nodeflare.app/chains/cronos)
+  * [Per-method API reference](https://nodeflare.app/docs/endpoints/cronos)
+  * [Service Status](https://nodeflare.app/status)


### PR DESCRIPTION
Adds NodeFlare to the commercial node providers list, following the same format as the existing entries.

NodeFlare serves Cronos mainnet (chain ID 25) from dedicated multi-region infrastructure with a free public endpoint (`https://rpc.nodeflare.app/cronos/public`, no API key) and a free keyed tier. Endpoint is live and verified.

